### PR TITLE
Occurrences of onSwipeSuccess changed to onSlideSuccess

### DIFF
--- a/SlideButton.js
+++ b/SlideButton.js
@@ -54,7 +54,7 @@ export class SlideButton extends Component {
           // Move the button out
           this.moveButtonOut(() => {
             self.setState({ swiped: true });
-            self.onSwipeSuccess();
+            self.onSlideSuccess();
           });
 
           // Slide it back in after 1 sec


### PR DESCRIPTION
An function call carelessly named as `self.onSwipeSuccess()` have been changed to `self.onSlideSuccess()`.
