### PR TITLE
Remove slideback timer when the component is unmounted

### DIFF
--- a/SlideButton.js
+++ b/SlideButton.js
@@ -28,7 +28,14 @@ export class SlideButton extends Component {
       animatedX: new Animated.Value(0),
       released: false,
       swiped: true,
+      slideBackTimer: null
     };
+  }
+
+  componentWillUnmount() {
+    if (this.state.slideBackTimer) {
+      clearTimeout(this.state.slideBackTimer);
+    }
   }
 
   /* Button movement of > 40% is considered a successful slide */
@@ -80,7 +87,7 @@ export class SlideButton extends Component {
           });
 
           // Slide it back in after 1 sec
-          setTimeout(() => {
+          var slideBackTimer = setTimeout(() => {
             self.moveButtonIn(() => {
               self.setState({
                 released: false,
@@ -89,6 +96,7 @@ export class SlideButton extends Component {
             });
           }, 1000);
 
+          self.setState({ slideBackTimer: slideBackTimer });
         } else {
           this.snapToPosition(() => {
             self.setState({


### PR DESCRIPTION
Remove slideback timer when the component is unmounted before the timeout has been triggered otherwise timeout is triggered when component is already unmounted.

https://github.com/sreejithr/react-native-slide-button/issues/10